### PR TITLE
Fixed "npm install" on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "postcss": "^4.0.0"
   },
   "scripts": {
-    "install": "./node_modules/bower-npm-install/bin/bower-npm-install"
+    "install": "node ./node_modules/bower-npm-install/bin/bower-npm-install"
   },
   "private": true
 }


### PR DESCRIPTION
Before I had the following error on Windows:

``` bash
> bem-highlight.js@0.2.3 install c:\GitHub\bem-highlight.js
> ./node_modules/bower-npm-install/bin/bower-npm-install

'.' is not recognized as an internal or external command,
operable program or batch file.
```

With `node ./node_modules/bower-npm-install/bin/bower-npm-install` installation process goes smoothly.
